### PR TITLE
Proposed: Add a doc about `.editorconfig`

### DIFF
--- a/docs/editorconfig.md
+++ b/docs/editorconfig.md
@@ -1,0 +1,38 @@
+# Editorconfig
+
+`.editorconfig` ensures consistent coding styles and settings across different editors and IDEs.
+
+These are settings like indentation and character encoding. Normalizing them makes collaboration smoother and code more uniform.
+
+## How to Use
+
+- Copy the contents of the code below.
+- Create an `.editorconfig` file at the root of your project.
+- Paste the contents into the file.
+
+These steps will automatically configure your text editor or IDE settings according to the defined rules when you open the project.
+
+In some cases, you may have to install a plugin for your editor to enable this feature, or quit and restart your editor for it to take effect.
+
+## `.editorconfig` File
+
+```ini
+# StellarWP EditorConfig
+#
+# https://github.com/stellarwp/global-docs/blob/main/docs/editorconfig.md
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.txt]
+trim_trailing_whitespace = false
+```


### PR DESCRIPTION
I noticed that the `.editorconfig` in the [solidwp-website](https://github.com/stellarwp/solidwp-website) project is the same as the one in [orderable-website](https://github.com/stellarwp/orderable-website), and figured it could be worth defining this somewhere for consistency.

We're using similar or outright-the-same rules elsewhere and it felt worth establishing a "standard".

At the same time, it doesn't feel like a "big" enough deal to warrant e.g. its own repo or something, and given how simple the file is, an `.md` file with the contents in a code block **seemed** like a sufficient-enough reference to me...

What do you think? 
